### PR TITLE
 Add ability to specify the output file name on the command line.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Example of Maven integration:
         <arguments>
           <argument>-cf</argument>
           <argument>my-config.json</argument>
+          <argument>--outputFile</argument>
+          <argument>${basedir}/src/main/webapp/validation/validation.json</argument>
       </configuration>
     </plugin>
   </plugins>

--- a/valdr-bean-validation/src/main/java/com/github/valdr/cli/ValdrBeanValidation.java
+++ b/valdr-bean-validation/src/main/java/com/github/valdr/cli/ValdrBeanValidation.java
@@ -61,6 +61,7 @@ public final class ValdrBeanValidation {
   private static Options loadOptions(CommandLine cli) {
     InputStream inputStream = null;
     String configFile = cli.getOptionValue("cf");
+    String outputFile = cli.getOptionValue("outputFile");
 
     try {
       if (StringUtils.isEmpty(configFile)) {
@@ -72,7 +73,11 @@ public final class ValdrBeanValidation {
         System.out.println("Building parser configuration from configured file path '" + configFile + "'.");
         inputStream = new FileInputStream(new File(configFile));
       }
-      return new ObjectMapper().readValue(inputStream, Options.class);
+      Options opt = new ObjectMapper().readValue(inputStream, Options.class);
+      if (StringUtils.isEmpty(opt.getOutputFile())) {
+         opt.setOutputFile(outputFile);
+      }
+      return opt;
     } catch (IOException e) {
       throw new IllegalArgumentException("Cannot read config file.", e);
     } finally {
@@ -110,6 +115,8 @@ public final class ValdrBeanValidation {
     org.apache.commons.cli.Options options = new org.apache.commons.cli.Options();
     options.addOption(new Option("cf", true,
       "path to JSON config file, if omitted valdr-bean-validation.json is " + "expected at root of class path"));
+    options.addOption(new Option("outputFile", true,
+      "path to output file, which will be used, if no outputFile is specified in the JSON config"));
     return options;
   }
 


### PR DESCRIPTION
This is required, in a maven multi-module setup, where relative path could point
to different files, when started as a parent or a sub-module build.
With this change, in the pom.xml you can specify --outputFile ${basedir}/validation.json